### PR TITLE
ext4_utils: disable ext4 64bit block support

### DIFF
--- a/ext4_utils/mke2fs.conf
+++ b/ext4_utils/mke2fs.conf
@@ -12,7 +12,7 @@
         features = has_journal
     }
     ext4 = {
-        features = has_journal,extent,huge_file,flex_bg,64bit,dir_nlink,extra_isize,uninit_bg
+        features = has_journal,extent,huge_file,flex_bg,dir_nlink,extra_isize,uninit_bg
         inode_size = 256
     }
     ext4dev = {


### PR DESCRIPTION
read_ext and vold full disk encryption can't handle 64bit block
address. Disable 64bit for now since 32bit can support 16TB file
system size.

Bug: 69234171
Change-Id: I7aab007e2e55f7416490e56864af1c69a9f55c9c