### PR TITLE
Remove -Wno-error from system/extras

### DIFF
--- a/memtrack/Android.mk
+++ b/memtrack/Android.mk
@@ -24,7 +24,7 @@ LOCAL_SRC_FILES := $(src_files)
 
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
 LOCAL_MODULE := memtrack_share
-LOCAL_CFLAGS := -Wall -Werror -Wno-error=unused-value
+LOCAL_CFLAGS := -Wall -Werror
 
 LOCAL_C_INCLUDES += $(includes)
 LOCAL_SHARED_LIBRARIES := \
@@ -38,7 +38,7 @@ LOCAL_ADDITIONAL_DEPENDENCIES := $(LOCAL_PATH)/Android.mk
 LOCAL_SRC_FILES := $(src_files)
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
 LOCAL_MODULE := memtrack
-LOCAL_CFLAGS := -Wall -Werror -Wno-error=unused-value
+LOCAL_CFLAGS := -Wall -Werror
 
 LOCAL_FORCE_STATIC_EXECUTABLE := true
 LOCAL_STATIC_LIBRARIES := \

--- a/memtrack/memtrack.cpp
+++ b/memtrack/memtrack.cpp
@@ -68,7 +68,7 @@ bool FileData::isAvail(size_t bytes_needed) {
   while (cur_idx_ + bytes_needed >= len_) {
     bytes = read(fd_, data_ + len_, max_ - len_);
     if (bytes == 0 || bytes == -1) {
-      read_complete_; // unused read?
+      read_complete_ = true;
       break;
     }
     len_ += bytes;

--- a/micro_bench/Android.mk
+++ b/micro_bench/Android.mk
@@ -6,7 +6,7 @@ LOCAL_SRC_FILES := micro_bench.cpp
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
 LOCAL_MODULE_TAGS := debug
 LOCAL_MODULE := micro_bench
-LOCAL_CFLAGS := -Wall -Werror -Wno-error=unused-variable
+LOCAL_CFLAGS := -Wall -Werror
 
 LOCAL_MULTILIB := both
 LOCAL_MODULE_STEM_32 := $(LOCAL_MODULE)
@@ -20,7 +20,7 @@ LOCAL_SRC_FILES := micro_bench.cpp
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
 LOCAL_MODULE_TAGS := debug
 LOCAL_MODULE := micro_bench_static
-LOCAL_CFLAGS := -Wall -Werror -Wno-error=unused-variable
+LOCAL_CFLAGS := -Wall -Werror
 LOCAL_STATIC_LIBRARIES = libc libm
 LOCAL_FORCE_STATIC_EXECUTABLE := true
 

--- a/micro_bench/micro_bench.cpp
+++ b/micro_bench/micro_bench.cpp
@@ -315,7 +315,7 @@ static void inline printColdSummary(
     size_t size = (cmd_data).args[0];                                         \
     size_t incr = getAlignmentIncrement(size, (cmd_data).dst_align);          \
     size_t num_buffers = (cmd_data).cold_data_size / incr;                    \
-    size_t buffer_size = num_buffers * incr;                                  \
+    size_t buffer_size __attribute__((__unused__)) = num_buffers * incr;      \
     uint8_t *buffer = getColdBuffer(num_buffers, incr, (cmd_data).dst_align, (cmd_data).dst_or_mask); \
     if (!buffer)                                                              \
         return -1;                                                            \
@@ -400,7 +400,6 @@ int benchmarkMemset(const char *name, const command_data_t &cmd_data, void_func_
 int benchmarkMemsetCold(const char *name, const command_data_t &cmd_data, void_func_t func) {
     memset_func_t memset_func = reinterpret_cast<memset_func_t>(func);
     COLD_ONE_BUF(name, cmd_data, ;, memset_func(buf, l, size));
-    (void)buffer_size;
 
     return 0;
 }
@@ -431,8 +430,8 @@ int benchmarkMemmoveBackwards(const char *name, const command_data_t &cmd_data, 
     memcpy_func_t memmove_func = reinterpret_cast<memcpy_func_t>(func);
 
     size_t size = cmd_data.args[0];
-    size_t alloc_size = size * 2 + 3 * cmd_data.dst_align; // should alloc_size be used?
-    uint8_t* src = allocateAlignedMemory(size, cmd_data.src_align, cmd_data.src_or_mask);
+    size_t alloc_size = size * 2 + 3 * cmd_data.dst_align;
+    uint8_t* src = allocateAlignedMemory(alloc_size, cmd_data.src_align, cmd_data.src_or_mask);
     if (!src)
         return -1;
     // Force memmove to do a backwards copy by getting a pointer into the source buffer.


### PR DESCRIPTION
Fix warnings in memtrack and micro_bench and remove -Wno-error.

Test: mmma system/extras
Change-Id: I48261f6af94c7fcba8a10e8fb558f47ab9d0e8be